### PR TITLE
Fix the saving of individual files

### DIFF
--- a/src/chrome/content/lookout.js
+++ b/src/chrome/content/lookout.js
@@ -456,23 +456,20 @@ LookoutStreamListener.prototype = {
 					fp.init(window, "Select a File", nsIFilePicker.modeSave);
 					fp.appendFilters(nsIFilePicker.filterAll);
 					fp.defaultString = this.cur_filename;
-					try {
-						fp.show(res => {
-							if (res != nsIFilePicker.returnCancel){
-								file_dir = fp.displayDirectory;
-								file_name = fp.file.leafName;
-							}
-						});
-					} catch(e) {
-						fp.open(res => {
-							if (res != nsIFilePicker.returnCancel){
-								file_dir = fp.displayDirectory;
-								file_name = fp.file.leafName;
-								// Move Temporary file to destination folder after dialogue closed
-								this.moveTMPFile( file, file_dir, file_name );
-							}
-						});
-					}
+
+					fp.open(res => {
+						if (res != nsIFilePicker.returnCancel) {
+							file_dir = fp.file.parent;
+							file_name = fp.file.leafName;
+
+							lookout.log_msg( "LookOut:     file_path: '" + fp.file.path + "'", 7 );
+							lookout.log_msg( "LookOut:     file_dir:  '" + file_dir.path + "'", 7 );
+							lookout.log_msg( "LookOut:     file_name: '" + file_name + "'", 7 );
+
+							// Move Temporary file to destination folder after dialogue closed
+							this.moveTMPFile(file, file_dir, file_name);
+						}
+					});
 	} else if (file_name) {
 			// Move Temporary file to destination folder
 			this.moveTMPFile( file, file_dir, file_name );


### PR DESCRIPTION
This commit fixes the saving of individual files by using
fp.file.parent instead of fp.displayDirectory to determine the parent
directory of the file to be saved that was chosen by the user.

According to [1], nsIFilePicker's "displayDirectory" attribute refers
to "the directory that the file picker should initially display", and
that it "should be set before calling open() or show()", whereas the
"file" attribute is file/directory selected by the user as a result of
the file picker dialog.

In addition, according to [2], nsIFilePicker's "show" method has been
obsolete since Gecko 57.0, so this commit removes the use of the show
method.

Fixes: #16

[1] https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsIFilePicker#Attributes
[2] https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsIFilePicker#show()_2