### PR TITLE
fix charset conversion

### DIFF
--- a/src/chrome/content/tnef.js
+++ b/src/chrome/content/tnef.js
@@ -489,7 +489,7 @@ function tnef_file_munge_fname( fname, files, code_page ) {
     if( charset != null ) {
       try {
         let decoder = new TextDecoder(charset);
-      	var fname2 = decoder.decode(new Uint8Array( fname ));
+      	var fname2 = decoder.decode(new Uint8Array( fname.split('').map( function( cur_char ){ return cur_char.charCodeAt(0); } ) ) );
       	try {
       		decodeURIComponent( escape( fname2 ) );
       	} catch (e) {


### PR DESCRIPTION
Multi-byte characters in file name are corrupted since conversion from string to Uint8Array is incorrect.

**Before :**
 ![before](https://user-images.githubusercontent.com/46066936/77246066-fb7da180-6c66-11ea-97c3-76f483fd73f2.png)
**After :** 
 ![after](https://user-images.githubusercontent.com/46066936/77246065-fa4c7480-6c66-11ea-8b6f-26858cb5ef47.png)
