### PR TITLE
fix: typo in lookout.js

### DIFF
--- a/src/chrome/content/lookout.js
+++ b/src/chrome/content/lookout.js
@@ -929,7 +929,7 @@ function LookoutLoad () {
 		// e.g. messageHeaderSink has been defined
 		if( typeof messageHeaderSink == 'undefined' ) {
 			if ( LookoutInitWait < LOOKOUT_WAIT_MAX ) {
-				LookoutInitWaitt++;
+				LookoutInitWait++;
 				lookout.log_msg( "LookOut:    waiting for global init [" + LookoutInitWait + "]", 6 );
 				//MKA  Function referencing in setTimeout() is deprecated by Mozilla,
 				//     so the following function expression is used.


### PR DESCRIPTION
Typo in lookout.js preventing start up.