### PR TITLE
Update for Thunderbird 128

### DIFF
--- a/src/api/Attachment/implementation.js
+++ b/src/api/Attachment/implementation.js
@@ -6,11 +6,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-var { ExtensionCommon } = ChromeUtils.import(
-  "resource://gre/modules/ExtensionCommon.jsm"
+var { ExtensionCommon } = ChromeUtils.importESModule(
+  "resource://gre/modules/ExtensionCommon.sys.mjs"
 );
-var { ExtensionUtils } = ChromeUtils.import(
-  "resource://gre/modules/ExtensionUtils.jsm"
+var { ExtensionUtils } = ChromeUtils.importESModule(
+  "resource://gre/modules/ExtensionUtils.sys.mjs"
 );
 var { ExtensionError } = ExtensionUtils;
 

--- a/src/api/LegacyPrefs/implementation.js
+++ b/src/api/LegacyPrefs/implementation.js
@@ -36,17 +36,13 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-var { ExtensionCommon } = ChromeUtils.import(
-  "resource://gre/modules/ExtensionCommon.jsm"
+var { ExtensionCommon } = ChromeUtils.importESModule(
+  "resource://gre/modules/ExtensionCommon.sys.mjs"
 );
-var { ExtensionUtils } = ChromeUtils.import(
-  "resource://gre/modules/ExtensionUtils.jsm"
+var { ExtensionUtils } = ChromeUtils.importESModule(
+  "resource://gre/modules/ExtensionUtils.sys.mjs"
 );
 var { ExtensionError } = ExtensionUtils;
-
-var Services = globalThis.Services || 
-  ChromeUtils.import("resource://gre/modules/Services.jsm").Services;
-
 
 var LegacyPrefs = class extends ExtensionCommon.ExtensionAPI {
   getAPI(context) {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -9,7 +9,7 @@
       "strict_max_version": "128.*"
     }
   },
-  "version": "6.2",
+  "version": "6.3",
   "default_locale": "en-US",
   "author": "Dugite-Code",
   "homepage_url": "https://github.com/TB-throwback/LookOut-fix-version/",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -6,7 +6,7 @@
     "gecko": {
       "id": "lookout@s3_fix_version",
       "strict_min_version": "115.0",
-      "strict_max_version": "115.*"
+      "strict_max_version": "128.*"
     }
   },
   "version": "6.2",


### PR DESCRIPTION
This removes no longer needed load for `Services` and no longer loads `*.jsm` files, but the new `*.sys.mjs` files.

The Thunderbird team was not able to publish the Attachments API yet, so we have to keep this as an Experiment. This API is still on the todo list, but due to chnaged priorities, it could not be finished in time.