### PR TITLE
Update for TB140 & TB141

### DIFF
--- a/src/api/Attachment/implementation.js
+++ b/src/api/Attachment/implementation.js
@@ -39,6 +39,16 @@ async function getRealFileForFile(file) {
   return tempFile;
 }
 
+function ClearAttachmentList(window) {
+  // clear selection
+  var list = window.document.getElementById("attachmentList");
+  list.clearSelection();
+
+  while (list.hasChildNodes()) {
+    list.lastChild.remove();
+  }
+}
+
 var Attachment = class extends ExtensionCommon.ExtensionAPI {
   getAPI(context) {
 
@@ -101,10 +111,10 @@ var Attachment = class extends ExtensionCommon.ExtensionAPI {
           return nativeTab.messageBrowser.contentWindow.gMessage;
         }
       } else if (nativeTab.mode.name == "mail3PaneTab") {
-          let msgHdrs = nativeTab.chromeBrowser.contentWindow.gDBView.getSelectedMsgHdrs();
-          if (msgHdrs.length == 1) {
-            return msgHdrs[0];
-          }
+        let msgHdrs = nativeTab.chromeBrowser.contentWindow.gDBView.getSelectedMsgHdrs();
+        if (msgHdrs.length == 1) {
+          return msgHdrs[0];
+        }
       } else if (nativeTab.mode.name == "mailMessageTab") {
         return nativeTab.chromeBrowser.contentWindow.gMessage;
       }
@@ -173,7 +183,7 @@ var Attachment = class extends ExtensionCommon.ExtensionAPI {
             return
           }
 
-          await window.ClearAttachmentList();
+          ClearAttachmentList(window);
           window.gBuildAttachmentsForCurrentMsg = false;
           await window.displayAttachmentsForExpandedView();
           window.gBuildAttachmentsForCurrentMsg = true;
@@ -197,7 +207,7 @@ var Attachment = class extends ExtensionCommon.ExtensionAPI {
             return
           }
 
-          await window.ClearAttachmentList();
+          ClearAttachmentList(window);
           window.gBuildAttachmentsForCurrentMsg = false;
           await window.displayAttachmentsForExpandedView();
           window.gBuildAttachmentsForCurrentMsg = true;

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -5,11 +5,11 @@
   "applications": {
     "gecko": {
       "id": "lookout@s3_fix_version",
-      "strict_min_version": "115.0",
+      "strict_min_version": "140.0",
       "strict_max_version": "140.*"
     }
   },
-  "version": "6.7",
+  "version": "6.8",
   "default_locale": "en-US",
   "author": "Dugite-Code",
   "homepage_url": "https://github.com/TB-throwback/LookOut-fix-version/",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -52,7 +52,8 @@
     "page": "background.html"
   },
   "permissions": [
-    "messagesRead"
+    "messagesRead",
+    "storage"
   ],
   "options_ui": {
     "page": "options/options.html"

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -6,7 +6,7 @@
     "gecko": {
       "id": "lookout@s3_fix_version",
       "strict_min_version": "140.0",
-      "strict_max_version": "140.*"
+      "strict_max_version": "141.*"
     }
   },
   "version": "6.8",

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -63,7 +63,7 @@
   </div>
 
   <script src="/scripts/i18n.js"></script>
-  <script src="/options/preferences.js"></script>
+  <script type="module" src="/options/preferences.js"></script>
 </body>
 
 </html>

--- a/src/options/preferences.js
+++ b/src/options/preferences.js
@@ -1,5 +1,6 @@
-const PREF_PREFIX = "extensions.lookout.";
-const PREF_NAMES = [
+import * as storage from "../scripts/storage.mjs";
+
+const USER_OPTIONS = [
   "attach_raw_mapi",
   "direct_to_calendar",
   "disable_filename_character_set",
@@ -8,17 +9,19 @@ const PREF_NAMES = [
   "debug_enabled",
 ]
 
+
 async function update(event) {
   let name = event.target.dataset.preference;
   let value = event.target.checked;
-  browser.LegacyPrefs.setPref( `${PREF_PREFIX}${name}`, value);
+  await browser.storage.local.set({ [name]: value })
 }
 
 async function init() {
   i18n.updateDocument();
+  let prefs = await storage.getPrefs();
 
-  for (let name of PREF_NAMES) {
-    let value = await browser.LegacyPrefs.getPref( `${PREF_PREFIX}${name}`);
+  for (let name of USER_OPTIONS) {
+    let value = prefs[name]; 
     let element = document.getElementById(`${name}_check`);
     element.checked = value;
     element.dataset.preference = name;

--- a/src/scripts/storage.mjs
+++ b/src/scripts/storage.mjs
@@ -1,0 +1,30 @@
+const PREF_PREFIX = "extensions.lookout.";
+const PREF_DEFAULTS = {
+  "attach_raw_mapi": false,
+  "direct_to_calendar": false,
+  "disable_filename_character_set": false,
+  "remove_winmail_dat": true,
+  "strict_contenttype": true,
+  "debug_enabled": false,
+  "body_part_prefix": "body_part_",
+}
+
+export async function migratePrefs() {
+  for (let name of Object.keys(PREF_DEFAULTS)) {
+    let value = await browser.LegacyPrefs.getUserPref(`${PREF_PREFIX}${name}`);
+    if (value !== null) {
+      console.info(`Migrating LookOut preference ${name} to local storage`);
+      await browser.storage.local.set({ [name]: value });
+      await browser.LegacyPrefs.clearUserPref(`${PREF_PREFIX}${name}`);
+    }
+  }
+}
+
+export async function getPrefs() {
+  // One option to access stored values is
+  //    let { option } = await browser.storage.local.get({ option: defaultValue })
+  // We can therefore simply pass in our PREF_DEFAULTS object and get back the
+  // desired prefs object, with the current values for each stored pref, or the
+  // associated default value.
+  return browser.storage.local.get(PREF_DEFAULTS)
+}


### PR DESCRIPTION
This PR migrates preferences to local storage (so that we can remove the LegacyPrefs API in the future) and also attempts to fix #127.

Thunderbird indeed does not need to clear the view after it has been created. But we do, since we remove the TNEF attachment.