### PR TITLE
Update Thunderbird compatibility to 150.*

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -6,7 +6,7 @@
     "gecko": {
       "id": "lookout@s3_fix_version",
       "strict_min_version": "140.0",
-      "strict_max_version": "144.*"
+      "strict_max_version": "150.*"
     }
   },
   "version": "7.1",


### PR DESCRIPTION
## Summary

This PR updates the Thunderbird maximum supported version in `src/manifest.json` from `144.*` to `150.*`.

## Testing

Tested manually on Thunderbird 150 using 15 Windows PCs and 50 test emails.

- The add-on installs correctly.
- winmail.dat extraction works.
- No errors were observed during testing.

## Notes

This change resolves the compatibility limit currently preventing installation on Thunderbird 150.