### PR TITLE
Fix compatibility for Thunderbird max_version 160

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,11 +2,11 @@
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
-  "applications": {
+  "browser_specific_settings": {
     "gecko": {
       "id": "lookout@s3_fix_version",
       "strict_min_version": "140.0",
-      "strict_max_version": "150.*"
+      "strict_max_version": "160.*"
     }
   },
   "version": "7.2",


### PR DESCRIPTION
Update manifest.json to support Thunderbird 153+ ESR by changing applications to browser_specific_settings and max_version to 160